### PR TITLE
Correção: Adicionar validação para SECRET_KEY para evitar erros de CSRF

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -14,6 +14,9 @@ def create_app():
     
     app.config.from_object(Config)
     
+    if not app.config['SECRET_KEY'] or app.config['SECRET_KEY'] == 'sua-chave-secreta-aqui-mude-em-producao':
+        raise ValueError("A SECRET_KEY não foi configurada ou está usando o valor padrão. Por favor, crie um arquivo .env, defina uma chave segura e reinicie a aplicação.")
+
     # Inicializar extensões
     db.init_app(app)
     csrf = CSRFProtect(app)


### PR DESCRIPTION
O aplicativo estava apresentando um erro "Token de sessão CSRF ausente" durante o login se a SECRET_KEY não estivesse configurada no ambiente. Isso acontecia porque o aplicativo iniciava com uma chave secreta `None`, impedindo o Flask-WTF de gerar e validar tokens de CSRF.

Adicionei uma verificação em `backend/app.py` para garantir que o aplicativo tenha uma SECRET_KEY válida na inicialização. Se a chave estiver ausente ou definida com o valor padrão do espaço reservado, o aplicativo gerará um ValueError com uma mensagem de erro explícita, orientando você a configurá-lo corretamente. Isso evita que o aplicativo seja executado em um estado inseguro e não funcional.