### PR TITLE
fix(config): Definir SESSION_COOKIE_SECURE com base em FLASK_ENV

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -14,7 +14,7 @@ class Config:
     
     # Configurações de segurança
     WTF_CSRF_TIME_LIMIT = None
-    SESSION_COOKIE_SECURE = True
+    SESSION_COOKIE_SECURE = os.environ.get('FLASK_ENV') != 'development'
     SESSION_COOKIE_HTTPONLY = True
     SESSION_COOKIE_SAMESITE = 'Lax'
     PERMANENT_SESSION_LIFETIME = timedelta(hours=2)


### PR DESCRIPTION
O aplicativo estava exibindo o erro "Token de sessão CSRF ausente" porque o sinalizador `SESSION_COOKIE_SECURE` estava codificado como `True`. Isso requer uma conexão HTTPS, mas o aplicativo estava sendo servido via HTTP no ambiente de desenvolvimento. Essa incompatibilidade fazia com que o navegador removesse o cookie de sessão, levando à falha na validação do CSRF.

Esta confirmação torna a configuração `SESSION_COOKIE_SECURE` condicional. Agora, ela é definida como `False` quando `FLASK_ENV` é `development` e `True` caso contrário. Isso alinha a política de segurança de cookies com o ambiente, resolvendo o erro CSRF durante o desenvolvimento local.

A confirmação anterior adicionou uma verificação para a SECRET_KEY, o que é uma melhoria válida para a robustez da configuração e foi mantida.